### PR TITLE
Qualifier synthesis + fixes and improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@ name = "hoice"
 version = "0.1.0"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.25.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashconsing 0.6.0 (git+https://github.com/AdrienChampion/hashconsing)",
@@ -79,7 +79,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clap"
-version = "2.25.1"
+version = "2.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -87,8 +87,8 @@ dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "textwrap 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-segmentation 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -194,7 +194,7 @@ dependencies = [
 [[package]]
 name = "mylib"
 version = "0.1.0"
-source = "git+https://github.com/AdrienChampion/mylib#43e7b1720b4216bb85da388a818e11ba71cc7a06"
+source = "git+https://github.com/AdrienChampion/mylib#8db71d2b244127dc5458b168cd31715cd22dd3f6"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -404,7 +404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
-"checksum clap 2.25.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7f1aabf260a8f3fefa8871f16b531038c98dd9eab1cfa2c575e78c459abfa3a0"
+"checksum clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2267a8fdd4dce6956ba6649e130f62fb279026e5e84b92aa939ac8f85ce3f9f0"
 "checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
 "checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
@@ -436,9 +436,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b6b55df3198cc93372e85dd2ed817f0e38ce8cc0f22eb32391bfad9c4bf209"
-"checksum textwrap 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f86300c3e7416ee233abd7cda890c492007a3980f941f79185c753a701257167"
+"checksum textwrap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f728584ea33b0ad19318e20557cb0a39097751dbb07171419673502f848c7af6"
 "checksum thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1697c4b57aeeb7a536b647165a2825faddffb1d3bad386d507709bd51a90bb14"
-"checksum unicode-segmentation 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18127285758f0e2c6cf325bb3f3d138a12fee27de4f23e146cd6a179f26c2cf3"
+"checksum unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8083c594e02b8ae1654ae26f0ade5158b119bd88ad0e8227a5d8fcd72407946"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,11 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -87,6 +92,19 @@ dependencies = [
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "conv"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "custom_derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "dbghelp-sys"
@@ -149,6 +167,23 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "magenta"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "magenta-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "memchr"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,7 +228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -241,10 +276,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rand"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -267,7 +303,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rsmt2"
 version = "0.6.0"
-source = "git+https://github.com/kino-mc/rsmt2#ddaac41fdf8ee7da31ed2a9173908263ec2042ba"
+source = "git+https://github.com/kino-mc/rsmt2#9c977e41d11bfe8f6d652a51094275c1de3c4ae5"
 dependencies = [
  "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -365,9 +401,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d912da0db7fa85514874458ca3651fe2cddace8d0b0505571dbdcd41ab490159"
 "checksum backtrace 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "72f9b4182546f4b04ebc4ab7f84948953a118bd6021a1b6a6c909e3e94f6be76"
 "checksum backtrace-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "afccc5772ba333abccdf60d55200fa3406f8c59dcf54d5f7998c9107d3799c7c"
+"checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum clap 2.25.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7f1aabf260a8f3fefa8871f16b531038c98dd9eab1cfa2c575e78c459abfa3a0"
+"checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
+"checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
 "checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
@@ -377,6 +416,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
 "checksum libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb7b49972ee23d8aa1026c365a5b440ba08e35075f18c459980c7395c221ec48"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
+"checksum magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf0336886480e671965f794bc9b6fce88503563013d1bfb7a502c81fe3ac527"
+"checksum magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40d014c7011ac470ae28e2f76a02bfea4a8480f73e701353b49ad7a8d75f4699"
 "checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
 "checksum mylib 0.1.0 (git+https://github.com/AdrienChampion/mylib)" = "<none>"
 "checksum nom 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06989cbd367e06f787a451f3bc67d8c3e0eaa10b461cc01152ffab24261a31b1"
@@ -387,7 +428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "7485fcc84f85b4ecd0ea527b14189281cf27d60e583ae65ebc9c088b13dffe01"
 "checksum num-rational 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "288629c76fac4b33556f4b7ab57ba21ae202da65ba8b77466e6d598e31990790"
 "checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
-"checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
+"checksum rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "eb250fd207a4729c976794d03db689c9be1d634ab5a1c9da9492a13d8fecbcdf"
 "checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum rsmt2 0.6.0 (git+https://github.com/kino-mc/rsmt2)" = "<none>"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ cargo build --release --features "bench"
 Note that this disables some features such as verbosity.
 
 
+## z3
+
+`hoice` relies on the [z3](https://github.com/Z3Prover/z3) SMT-solver. Make sure you have a relatively recent version of the z3 binary in your path.
+
+
 # Language
 
 [Consult the wiki](https://github.com/hopv/hoice/wiki/Language) for a description of `hoice`'s language.

--- a/src/common/data.rs
+++ b/src/common/data.rs
@@ -155,6 +155,14 @@ impl Data {
     }
   }
 
+  /// Performs an action on all samples.
+  pub fn samples_fold<T, F>(& self, init: T, f: F) -> Res<T>
+  where F: Fn(T, HSample) -> T {
+    Ok(
+      self.samples.read().map_err(corrupted_err)?.fold(f, init)
+    )
+  }
+
   /// The projected data for some predicate.
   pub fn data_of(& self, pred: PrdIdx) -> Res<::learning::ice::CData> {
     let pred_map = self.map[pred].read().map_err(corrupted_err)? ;
@@ -211,10 +219,6 @@ impl Data {
   }
 
   /// Adds a positive example. Simplifies constraints containing that sample.
-  ///
-  /// # TO DO
-  ///
-  /// - look at the clauses that became unit and propagate
   pub fn add_pos(
     & self, pred: PrdIdx, args: Args
   ) -> Res<Sample> {
@@ -324,10 +328,6 @@ impl Data {
   }
 
   /// Adds a negative example. Simplifies constraints containing that sample.
-  ///
-  /// # TO DO
-  ///
-  /// - look at the clauses that became unit and propagate
   pub fn add_neg(
     & self, pred: PrdIdx, args: Args
   ) -> Res<Sample> {
@@ -428,10 +428,6 @@ impl Data {
   }
 
   /// Adds a constraint. Propagates positive and negative samples.
-  ///
-  /// # TO DO
-  ///
-  /// - detect unit clauses and propagate right away
   pub fn add_cstr(
     & self,
     lhs: Vec<(PrdIdx, Args)>, rhs: Option< (PrdIdx, Args) >

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -132,16 +132,6 @@ impl<T: fmt::Display> fmt::Display for VarMap<T> {
   }
 }
 
-
-wrap_usize!{
-  #[doc = "Arity."]
-  Arity
-  #[doc = "Range over arity."]
-  range: ArityRange
-  #[doc = "Total map from Arity to something."]
-  map: ArityMap with iter: ArityMapIter
-}
-
 impl ::rsmt2::Sym2Smt<()> for VarIdx {
   fn sym_to_smt2<Writer>(
     & self, w: & mut Writer, _: & ()
@@ -151,6 +141,25 @@ impl ::rsmt2::Sym2Smt<()> for VarIdx {
       write!(w, "v_{}", self)
     }
   }
+}
+
+impl ::rsmt2::Expr2Smt<()> for VarIdx {
+  fn expr_to_smt2<Writer>(
+    & self, w: & mut Writer, _: & ()
+  ) -> SmtRes<()> where Writer: Write {
+    use ::rsmt2::Sym2Smt ;
+    self.sym_to_smt2(w, & ())
+  }
+}
+
+
+wrap_usize!{
+  #[doc = "Arity."]
+  Arity
+  #[doc = "Range over arity."]
+  range: ArityRange
+  #[doc = "Total map from Arity to something."]
+  map: ArityMap with iter: ArityMapIter
 }
 
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -57,9 +57,33 @@ macro_rules! if_verb {
 macro_rules! if_verb {
   ($($blah:tt)*) => (()) ;
 }
+
+
+
+/// Logs at info level. Deactivated in release.
+#[cfg( feature = "bench" )]
+macro_rules! log_info {
+  ($($tt:tt)*) => (()) ;
+}
+#[cfg( not(feature = "bench") )]
+macro_rules! log_info {
+  ($($tt:tt)*) => ( info!{$($tt)*} ) ;
+}
+
+
+/// Logs at debug level. Deactivated in release.
+#[cfg( feature = "bench" )]
+macro_rules! log_debug {
+  ($($tt:tt)*) => (()) ;
+}
+#[cfg( not(feature = "bench") )]
+macro_rules! log_debug {
+  ($($tt:tt)*) => ( debug!{$($tt)*} ) ;
+}
+
+
 /// Does something if in debug mode.
 #[macro_export]
-#[allow(unused_macros)]
 #[cfg(not (feature = "bench") )]
 macro_rules! if_debug {
   ($($blah:tt)*) => (
@@ -69,6 +93,7 @@ macro_rules! if_debug {
   ) ;
 }
 #[cfg(feature = "bench")]
+#[allow(unused_macros)]
 macro_rules! if_debug {
   ($($blah:tt)*) => (()) ;
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -55,10 +55,11 @@ macro_rules! if_verb {
 }
 #[cfg(feature = "bench")]
 macro_rules! if_verb {
-  ($($blah:tt)*) => () ;
+  ($($blah:tt)*) => (()) ;
 }
 /// Does something if in debug mode.
 #[macro_export]
+#[allow(unused_macros)]
 #[cfg(not (feature = "bench") )]
 macro_rules! if_debug {
   ($($blah:tt)*) => (
@@ -69,7 +70,7 @@ macro_rules! if_debug {
 }
 #[cfg(feature = "bench")]
 macro_rules! if_debug {
-  ($($blah:tt)*) => () ;
+  ($($blah:tt)*) => (()) ;
 }
 
 

--- a/src/common/msg.rs
+++ b/src/common/msg.rs
@@ -63,6 +63,16 @@ macro_rules! msg {
 }
 #[cfg( not(feature = "bench") )]
 macro_rules! msg {
+  ( debug $slf:expr => $($tt:tt)* ) => (
+    if conf.verb == Verb::Debug {
+      msg!( $slf => $($tt)* )
+    } else { true }
+  ) ;
+  ( $slf:expr => $e:expr ) => (
+    ::common::msg::HasLearnerCore::msg(
+      $slf, $e
+    )
+  ) ;
   ( $slf:expr => $($tt:tt)* ) => (
     ::common::msg::HasLearnerCore::msg(
       $slf, format!( $($tt)* )

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -71,6 +71,11 @@ error_chain!{
       description("parse error")
       display("{}", data)
     }
+    #[doc = "Could not spawn z3."]
+    Z3SpawnError {
+      description("could not spawn z3")
+      display("could not spawn z3")
+    }
   }
 }
 
@@ -81,7 +86,7 @@ pub fn print_err(errs: Error) {
   for_first!(
     errs.iter() => {
       |err| lines = format!("{}", err),
-      then |err| lines = format!("{}\n{}", err, lines),
+      then |err| lines = format!("{}\n{}", lines, err),
       yild error!{"{}", lines}
     } else ()
   )

--- a/src/instance/build.rs
+++ b/src/instance/build.rs
@@ -355,6 +355,10 @@ impl InstBuild {
       alt_complete!(
         map!(
           int, |n| {
+            let cst = self.instance.int(n.clone() + 1) ;
+            let _ = self.instance.consts.insert( cst.clone() ) ;
+            let cst = self.instance.int(n.clone() - 1) ;
+            let _ = self.instance.consts.insert( cst.clone() ) ;
             let cst = self.instance.int(n) ;
             let _ = self.instance.consts.insert( cst.clone() ) ;
             cst
@@ -618,5 +622,12 @@ impl InstBuild {
         None
       },
     }
+  }
+
+
+
+  /// Reduces the instance.
+  pub fn reduce(& mut self) -> Res<()> {
+    Ok(())
   }
 }

--- a/src/learning/ice/mining.rs
+++ b/src/learning/ice/mining.rs
@@ -253,7 +253,7 @@ impl Qualifiers {
     & 'a mut self, qual: Term, data: & Data
   ) -> Res<& 'a QualValues> {
     let arity: Arity = if let Some(max_var) = qual.highest_var() {
-      (* max_var).into()
+      (1 + * max_var).into()
     } else {
       bail!("[bug] trying to add constant qualifier")
     } ;

--- a/src/learning/smt.rs
+++ b/src/learning/smt.rs
@@ -18,8 +18,8 @@ impl Launcher {
   pub fn launch(
     core: & LearnerCore, instance: Arc<Instance>
   ) -> Res<()> {
-    use rsmt2::{ solver, SolverConf, Kid } ;
-    let mut kid = Kid::mk( SolverConf::z3() ).chain_err(
+    use rsmt2::{ solver, Kid } ;
+    let mut kid = Kid::mk( conf.solver_conf() ).chain_err(
       || "while spawning the teacher's solver"
     ) ? ;
     let solver = solver(& mut kid, Parser).chain_err(

--- a/src/teacher/mod.rs
+++ b/src/teacher/mod.rs
@@ -264,6 +264,7 @@ impl<'kid, S: Solver<'kid, Parser>> Teacher<S> {
   pub fn get_cexs(& mut self, cands: & Candidates) -> Res< Cexs > {
     let mut map = ClsHMap::with_capacity( self.instance.clauses().len() ) ;
     let clauses = ClsRange::zero_to( self.instance.clauses().len() ) ;
+    self.solver.comment("looking for counterexamples...") ? ;
     for clause in clauses {
       if let Some(cex) = self.get_cex(cands, clause).chain_err(
         || format!("while getting counterexample for clause {}", clause)


### PR DESCRIPTION
- various bug fixes
- added implications in the internal term structure
- trivial predicate detection
- clause simplification

# Qualifier synthesis

Given a predicate, qualifier synthesis kicks in when two "points" cannot be separated with the current qualifiers. If the signature of the qualifier is `x_1, ..., x_n` then synthesis uses an SMT solver to find some constants `a, a_1, ..., a_n` such that `a_1 . x_1 + ... + a_n . x_n + a >= 0` separates the two points.

The synthetic qualifier is then added to the set of qualifier and can be used afterwards as a normal qualifier. The downside is that this approach is entropy-agnostic, there is no evaluation of how good the qualifier is.

An alternative would be to generate more qualifiers when two points cannot be separated, and then find the best one with the usual entropy mechanism. This would potentially be more efficient as the best qualifier entropy-wise would be selected.