### PR TITLE
Synthesis, mining, handling simple samples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
  "dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -58,7 +58,7 @@ name = "backtrace-sys"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "gcc"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -194,7 +194,7 @@ dependencies = [
 [[package]]
 name = "mylib"
 version = "0.1.0"
-source = "git+https://github.com/AdrienChampion/mylib#3401877e499eb9154d598c1776ba4950725fe8f6"
+source = "git+https://github.com/AdrienChampion/mylib#bab995e9943f678002f12b5fe2d772558928dee1"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -311,7 +311,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -410,7 +410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
 "checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
-"checksum gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)" = "120d07f202dcc3f72859422563522b66fe6463a4c513df062874daad05f85f0a"
+"checksum gcc 0.3.53 (registry+https://github.com/rust-lang/crates.io-index)" = "e8310f7e9c890398b0e80e301c4f474e9918d2b27fca8f48486ca775fa9ffc5a"
 "checksum hashconsing 0.6.0 (git+https://github.com/AdrienChampion/hashconsing)" = "<none>"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
@@ -432,7 +432,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum rsmt2 0.6.0 (git+https://github.com/kino-mc/rsmt2)" = "<none>"
-"checksum rustc-demangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3058a43ada2c2d0b92b3ae38007a2d0fa5e9db971be260e0171408a4ff471c95"
+"checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b6b55df3198cc93372e85dd2ed817f0e38ce8cc0f22eb32391bfad9c4bf209"

--- a/src/common/data.rs
+++ b/src/common/data.rs
@@ -362,10 +362,12 @@ impl Data {
         curr_samples.len(), self.instance[curr_pred]
       ) ;
 
+      let mut new_stuff = false ;
       for sample in & curr_samples {
         let is_new = self.pos[curr_pred].insert( sample.clone() ) ;
-        debug_assert!( is_new )
+        new_stuff = new_stuff || is_new
       }
+      if ! new_stuff { continue 'propagate }
 
       // Get the constraints mentioning the positive samples.
       let mut constraints ;
@@ -521,10 +523,12 @@ impl Data {
     ) = to_propagate.pop() {
       if curr_samples.is_empty() { continue }
 
+      let mut new_stuff = false ;
       for sample in & curr_samples {
         let is_new = self.neg[curr_pred].insert( sample.clone() ) ;
-        debug_assert!( is_new )
+        new_stuff = new_stuff || is_new
       }
+      if ! new_stuff { continue 'propagate }
 
       log_debug!(
         "propagating {} samples for predicate {}",

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -995,18 +995,26 @@ impl CanPrint for ProfileTree {
 
 /// Profiling macro.
 ///
-/// Takes a `self` that has a `_profiler` field.
+/// If passed `self`, assumes `self` has a `_profiler` field.
 #[macro_export]
 #[cfg( not(feature = "bench") )]
 macro_rules! profile {
-  ( $slf:ident $stat:expr => add $e:expr ) => (
-    $slf._profiler.stat_do( $stat, |val| val + $e )
+  ( | $prof:ident | $stat:expr => add $e:expr ) => (
+    $prof.stat_do( $stat, |val| val + $e )
   ) ;
-  ( $slf:ident $meth:ident $( $scope:expr ),+ $(,)* ) => (
-    $slf._profiler.$meth(
+  ( | $prof:ident | $meth:ident $( $scope:expr ),+ $(,)* ) => (
+    $prof.$meth(
       vec![ $($scope),+ ]
     )
   ) ;
+  ( $slf:ident $stat:expr => add $e:expr ) => ({
+    let prof = & $slf._profiler ;
+    profile!{ |prof| $stat => add $e }
+  }) ;
+  ( $slf:ident $meth:ident $( $scope:expr ),+ $(,)* ) => ({
+    let prof = & $slf._profiler ;
+    profile!{ |prof| $meth $($scope),+ }
+  }) ;
 }
 #[cfg(feature = "bench")]
 macro_rules! profile {

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -366,6 +366,7 @@ pub struct Conf {
   pub out_dir: String,
   pub smt_learn: bool,
   pub z3_cmd: String,
+  pub fpice_synth: bool,
   pub step: bool,
   pub verb: Verb,
   pub stats: bool,
@@ -379,11 +380,11 @@ impl Conf {
   pub fn mk(
     file: Option<String>, check: Option<String>,
     smt_log: bool, z3_cmd: String, out_dir: String,
-    step: bool, smt_learn: bool, 
+    step: bool, smt_learn: bool, fpice_synth: bool,
     verb: Verb, stats: bool, color: bool
   ) -> Self {
     Conf {
-      file, check, smt_log, out_dir, step, smt_learn, z3_cmd,
+      file, check, smt_log, out_dir, step, smt_learn, fpice_synth, z3_cmd,
       verb, stats, styles: Styles::mk(color)
     }
   }
@@ -521,6 +522,16 @@ impl Conf {
         "<FILE>"
       ).takes_value(true).number_of_values(1)
 
+    // ).arg(
+
+    //   Arg::with_name("fpice_synth").long("--fpice_synth").help(
+    //     "activates fpice-style synthesis"
+    //   ).validator(
+    //     bool_validator
+    //   ).value_name(
+    //     bool_format
+    //   ).default_value("on").takes_value(true).number_of_values(1)
+
     ).arg(
 
       Arg::with_name("stats").long("--stats").help(
@@ -563,6 +574,12 @@ impl Conf {
     let check = matches.value_of("check").map(
       |s| s.to_string()
     ) ;
+    let fpice_synth = true ;
+    // matches.value_of("fpice_synth").and_then(
+    //   |s| bool_of_str(& s)
+    // ).expect(
+    //   "unreachable(fpice_synth): default is provided and input validated in clap"
+    // ) ;
     let stats = matches.value_of("stats").and_then(
       |s| bool_of_str(& s)
     ).expect(
@@ -580,7 +597,7 @@ impl Conf {
 
     Conf::mk(
       file, check, smt_log, z3_cmd.into(), out_dir.into(), step, smt_learn,
-      verb, stats, color
+      fpice_synth, verb, stats, color
     )
   }
 }

--- a/src/instance/build.rs
+++ b/src/instance/build.rs
@@ -556,15 +556,6 @@ impl InstBuild {
       bytes,
       InternalParseError,
       alt_complete!(
-        // Negation of a term.
-        do_parse!(
-          char!('(') >>
-          spc_cmt >> tag!("not") >>
-          spc_cmt >> term: try_call!( self.parse_term(& vars) ) >>
-          spc_cmt >> char!(')') >> (
-            TTerm::N(term)
-          )
-        ) |
         // Predicate application.
         do_parse!(
           char!('(') >>

--- a/src/instance/mod.rs
+++ b/src/instance/mod.rs
@@ -325,6 +325,17 @@ impl RTerm {
       _ => None,
     }
   }
+
+  /// If the term is a negation, returns what's below the negation.
+  pub fn rm_neg(& self) -> Option<Term> {
+    match * self {
+      RTerm::App { op: Op::Not, ref args } => {
+        debug_assert_eq!( args.len(), 1 ) ;
+        Some( args[0].clone() )
+      },
+      _ => None,
+    }
+  }
 }
 impl_fmt!{
   RTerm(self, fmt) {
@@ -376,8 +387,6 @@ pub enum TTerm {
     /// The arguments.
     args: VarMap<Term>,
   },
-  /// Negation of something.
-  N(Term),
   /// Just a term.
   T(Term),
 }
@@ -385,7 +394,6 @@ impl TTerm {
   /// True if the term is equivalent to `true`.
   pub fn is_true(& self) -> bool {
     match * self {
-      TTerm::N(ref t) => t.is_false(),
       TTerm::T(ref t) => t.is_true(),
       _ => false,
     }
@@ -393,7 +401,6 @@ impl TTerm {
   /// True if the term is equivalent to `false`.
   pub fn is_false(& self) -> bool {
     match * self {
-      TTerm::N(ref t) => t.is_true(),
       TTerm::T(ref t) => t.is_false(),
       _ => false,
     }
@@ -411,11 +418,6 @@ impl TTerm {
     use self::TTerm::* ;
     match * self {
       P { pred, ref args } => write_prd(w, pred, args),
-      N(ref t) => {
-        write!(w, "(not ") ? ;
-        t.write(w, write_var) ? ;
-        write!(w, ")", )
-      },
       T(ref t) => t.write(w, write_var),
     }
   }
@@ -443,7 +445,6 @@ impl_fmt!{
         }
         write!(fmt, ")")
       },
-      TTerm::N(ref t) => write!(fmt, "(not {})", t),
       TTerm::T(ref t) => write!(fmt, "{}", t),
     }
   }
@@ -575,6 +576,136 @@ impl ::rsmt2::Expr2Smt<Candidates> for Clause {
 }
 
 
+/// Type of the underlying factory.
+type Factory = RwLock< HashConsign<RTerm> > ;
+
+
+
+/// Performs variable substitution over terms.
+pub trait SubstExt {
+  /// Variable substitution.
+  ///
+  /// Returns the new term and a boolean indicating whether any substitution
+  /// occured.
+  ///
+  /// Used for substitutions in the same clause / predicate scope.
+  fn subst(
+    & self, map: & VarHMap<Term>, term: & Term
+  ) -> (Term, bool) {
+    self.subst_custom(map, term, false).expect("total substitution can't fail")
+  }
+
+  /// Fixed-point variable substitution.
+  ///
+  /// Returns the new term and a boolean indicating whether any substitution
+  /// occured.
+  fn subst_fp(& self, map: & VarHMap<Term>, term: & Term) -> (Term, bool) {
+    let (mut term, mut changed) = self.subst(map, term) ;
+    while changed {
+      let (new_term, new_changed) = self.subst(map, & term) ;
+      term = new_term ;
+      changed = new_changed
+    }
+    (term, changed)
+  }
+
+  /// Total variable substition, returns `None` if there was a variable in the
+  /// term that was not in the map.
+  ///
+  /// Returns the new term and a boolean indicating whether any substitution
+  /// occured.
+  ///
+  /// Used for substitutions between different same clause / predicate scopes.
+  fn subst_total(
+    & self, map: & VarHMap<Term>, term: & Term
+  ) -> Option< (Term, bool) > {
+    self.subst_custom(map, term, true)
+  }
+
+  /// Variable substitution.
+  ///
+  /// Returns the new term and a boolean indicating whether any substitution
+  /// occured.
+  ///
+  /// The substitution *fails* by returning `None` if
+  ///
+  /// - `total` and the term contains a variable that's not in the map
+  ///
+  /// Used by qualifier extraction.
+  fn subst_custom(
+    & self, map: & VarHMap<Term>, term: & Term, total: bool
+  ) -> Option<(Term, bool)> ;
+}
+
+impl SubstExt for Factory {
+  fn subst_custom(
+    & self, map: & VarHMap<Term>, term: & Term, total: bool
+  ) -> Option<(Term, bool)> {
+    let mut current = term ;
+    // Stack for traversal.
+    let mut stack = vec![] ;
+    // Number of substitutions performed.
+    let mut subst_count = 0 ;
+
+    'go_down: loop {
+
+      // Go down.
+      let mut term = match * current.get() {
+        RTerm::Var(var) => if let Some(term) = map.get(& var) {
+          subst_count += 1 ;
+          term.clone()
+        } else if total {
+          return None
+        } else {
+          current.clone()
+        },
+        RTerm::App { op, ref args } => {
+          current = & args[0] ;
+          stack.push(
+            (op, & args[1..], Vec::with_capacity( args.len() ))
+          ) ;
+          continue 'go_down
+        },
+        _ => current.clone(),
+      } ;
+
+      // Go up.
+      'go_up: while let Some(
+        (op, args, mut new_args)
+      ) = stack.pop() {
+        new_args.push( term ) ;
+        
+        if args.is_empty() {
+          term = self.mk( RTerm::App { op, args: new_args } ) ;
+          continue 'go_up // Just for readability
+        } else {
+          current = & args[0] ;
+          stack.push( (op, & args[1..], new_args) ) ;
+          continue 'go_down
+        }
+      }
+
+      // Only way to get here is if the stack is empty, meaning we're done.
+      return Some( (term, subst_count > 0) )
+    }
+  }
+}
+
+
+
+
+
+impl SubstExt for Instance {
+  fn subst_custom(
+    & self, map: & VarHMap<Term>, term: & Term, total: bool
+  ) -> Option<(Term, bool)> {
+    self.factory.subst_custom(map, term, total)
+  }
+}
+
+
+
+
 
 
 /// Stores the instance: the clauses, the factory and so on.
@@ -585,7 +716,7 @@ impl ::rsmt2::Expr2Smt<Candidates> for Clause {
 /// simplifications that can remove clauses.
 pub struct Instance {
   /// Term factory.
-  factory: RwLock< HashConsign<RTerm> >,
+  factory: Factory,
   /// Constants constructed so far.
   consts: HConSet<RTerm>,
   /// Predicates.
@@ -755,74 +886,204 @@ impl Instance {
     self.op(Op::Eql, vec![lhs, rhs])
   }
 
-  /// Variable substitution.
+  /// Simplifies the clauses.
   ///
-  /// If the term contains a variable that's not in the map then the
-  /// substitution *fails* by returning `None`.
+  /// - propagates the equalities in all the clauses
   ///
-  /// Used by qualifier extraction.
-  pub fn subst(
-    & self, map: VarHMap<Term>, term: & Term
-  ) -> Option<Term> {
-    let mut current = term ;
-    // Stack for traversal.
-    let mut stack = vec![] ;
+  /// # TODO
+  ///
+  /// - currently kind of assumes equalities are binary, fix?
+  pub fn simplify_clauses(& mut self) -> Res<()> {
+    for clause in & mut self.clauses {
+      // println!(
+      //   "looking at clause\n{}", clause.to_string_info(& self.preds) ?
+      // ) ;
 
-    'go_down: loop {
+      let mut maps = vec![
+        VarHMap::with_capacity( clause.lhs().len() + 1 )
+      ] ;
 
-      // Go down.
-      let mut term = match * current.get() {
-        RTerm::Var(var) => if let Some(term) = map.get(& var) {
-          term.clone()
-        } else {
-          return None
-        },
-        RTerm::App { op, ref args } => {
-          current = & args[0] ;
-          stack.push(
-            (op, & args[1..], Vec::with_capacity( args.len() ))
-          ) ;
-          continue 'go_down
-        },
-        _ => current.clone(),
-      } ;
-
-      // Go up.
-      'go_up: while let Some(
-        (op, args, mut new_args)
-      ) = stack.pop() {
-        new_args.push( term ) ;
-        
-        if args.is_empty() {
-          term = self.op(op, new_args) ;
-          continue 'go_up // Just for readability
-        } else {
-          current = & args[0] ;
-          stack.push( (op, & args[1..], new_args) ) ;
-          continue 'go_down
+      // Find equalities and add to map.
+      //
+      // Iterating with a counter so that we can remove terms on the fly with
+      // `swap_remove`.
+      let mut cnt = 0 ;
+      'lhs_iter: while cnt < clause.lhs.len() {
+        let current = cnt ;
+        cnt += 1 ; // Incrementing because moving on is done via `continue`.
+        match clause.lhs[current] {
+          TTerm::T(ref term) => match * term.get() {
+            RTerm::App { op: Op::Eql, ref args } => {
+              debug_assert!( args.len() >= 2 ) ;
+              let mut to_add = vec![] ;
+              // Is the lhs a variable?
+              let (var, term) = if let Some(idx) = args[0].var_idx() {
+                (idx, & args[1])
+              } else if let Some(idx) = args[1].var_idx() {
+                (idx, & args[0])
+              } else {
+                continue 'lhs_iter
+              };
+              for map in & mut maps {
+                if map.contains_key(& var) {
+                  let mut map = map.clone() ;
+                  map.insert( var, term.clone()  ) ;
+                  to_add.push(map)
+                } else {
+                  let _ = map.insert( var, term.clone() ) ;
+                }
+              }
+              for map in to_add {
+                maps.push(map)
+              }
+            },
+            _ => continue 'lhs_iter,
+          },
+          _ => continue 'lhs_iter,
         }
+
+        // Only reachable if the top term was an equality we're gonna
+        // propagate.
+        // println!(
+        //   "  forgetting top term {}", clause.lhs[current]
+        // ) ;
+        clause.lhs.swap_remove(current) ;
+        cnt = current
+        // * tterm = TTerm::T( self.factory.mk( RTerm::Bool(true) ) )
       }
 
-      // Only way to get here is if the stack is empty, meaning we're done.
-      return Some(term)
+      // println!("  performing {} map propagations", maps.len()) ;
+
+      // Remove all the variables in the maps from the clause using fixed-point
+      // substitution.
+      for map in maps {
+        use mylib::coll::* ;
+        for tterm in clause.lhs.iter_mut().chain_one( & mut clause.rhs ) {
+          match * tterm {
+            TTerm::P { ref mut args, .. } => for arg in args {
+              let (new_arg, _) = self.factory.subst_fp(& map, arg) ;
+              // println!("  - arg {} -> {}", arg, new_arg) ;
+              * arg = new_arg
+            },
+            TTerm::T(ref mut term) => {
+              let (new_term, _) = self.factory.subst_fp(& map, term) ;
+              // println!("  - trm {} -> {}", term, new_term) ;
+              * term = new_term
+            },
+          }
+        }
+      }
     }
+    Ok(())
   }
 
-  // /// Extracts some qualifiers from a clause.
-  // ///
-  // /// # TO DO
-  // ///
-  // /// - write an explanation of what actually happens
-  // /// - and some tests, probably
-  // pub fn qualifiers_of_clause(& self, clause: & Clause) -> HConSet<RTerm> {
+  /// Extracts some qualifiers from all clauses.
+  pub fn qualifiers(& self) -> HConSet<RTerm> {
+    let mut set = HConSet::new() ;
+    for clause in & self.clauses {
+      self.qualifiers_of_clause(clause, & mut set)
+    }
+    set
+  }
 
-  //   // Extraction of the variables map based on the way the predicates are
-  //   // used.
-  //   let maps = 
+  /// Extracts some qualifiers from a clause.
+  ///
+  /// # TO DO
+  ///
+  /// - write an explanation of what actually happens
+  /// - and some tests, probably
+  pub fn qualifiers_of_clause(
+    & self, clause: & Clause, quals: & mut HConSet<RTerm>
+  ) {
+    use mylib::coll::* ;
 
-  //   unimplemented!()
+    // println!(
+    //   "looking at clause {}", clause.to_string_info(self.preds()).unwrap()
+    // ) ;
 
-  // }
+    // Extraction of the variables map based on the way the predicates are
+    // used.
+    let mut maps = vec![] ;
+
+    for tterm in clause.lhs().iter().chain_one( clause.rhs() ) {
+      match * tterm {
+        
+        TTerm::P { ref args, .. } => {
+          // All the *clause var* to *pred var* maps for this predicate
+          // application.
+          let mut these_maps = vec![ VarHMap::with_capacity( args.len() ) ] ;
+
+          for (pred_var_index, term) in args.index_iter() {
+            if let Some(clause_var_index) = term.var_idx() {
+              // Stores the new maps to add in case a clause variable is bound
+              // several times.
+              let mut to_add = vec![] ;
+              for map in & mut these_maps {
+                if map.contains_key(& clause_var_index) {
+                  // Current clause variable is already bound in this map,
+                  // clone it, change the binding, and remember to add it
+                  // later.
+                  let mut map = map.clone() ;
+                  let _ = map.insert(
+                    clause_var_index, self.var(pred_var_index)
+                  ) ;
+                  to_add.push(map)
+                } else {
+                  // Current clause variable not bound in this map, just add
+                  // the new binding.
+                  let _ = map.insert(
+                    clause_var_index, self.var(pred_var_index)
+                  ) ;
+                }
+              }
+              use std::iter::Extend ;
+              these_maps.extend( to_add )
+            }
+          }
+
+          for map in these_maps {
+            // Push if non-empty.
+            if ! map.is_empty() {
+              maps.push(map)
+            }
+          }
+        },
+        
+        _ => ()
+      }
+    }
+
+    // println!("maps {{") ;
+    // for map in & maps {
+    //   let mut is_first = true ;
+    //   for (idx, term) in map.iter() {
+    //     println!("  {} {} -> {}", if is_first {"-"} else {" "}, idx, term) ;
+    //     is_first = false
+    //   }
+    // }
+    // println!("}} quals {{") ;
+
+    // Now look for atoms and try to apply the mappings above.
+    for tterm in clause.lhs().iter().chain_one( clause.rhs() ) {
+
+      match * tterm {
+        TTerm::T(ref term) => for map in & maps {
+          if let Some( (term, true) ) = self.subst_total(map, term) {
+            // println!("  - {}", term) ;
+            let term = if let Some(term) = term.rm_neg() {
+              term
+            } else { term } ;
+            let _ = quals.insert(term) ;
+          }
+        },
+        _ => ()
+      }
+
+    }
+
+    // println!("}}")
+
+  }
 
   /// Turns a teacher counterexample into learning data.
   pub fn cexs_to_data(
@@ -970,7 +1231,7 @@ impl Op {
 
   /// Tries to simplify an operator application.
   ///
-  /// Currently only simplifies nullary / unary applications of `And` and `Or`.
+  /// # Nullary / unary applications of `And` and `Or`
   ///
   /// ```
   /// let instance = & Instance::mk(10, 10, 10) ;
@@ -992,6 +1253,22 @@ impl Op {
   ///   or, Op::Or.simplify(instance, vec![ and.clone(), var_2.clone() ])
   /// ) ;
   /// ```
+  ///
+  /// # Double negations
+  ///
+  /// ```
+  /// let instance = & Instance::mk(10, 10, 10) ;
+  /// let tru = instance.bool(true) ;
+  /// let fls = instance.bool(false) ;
+  /// let var_1 = instance.var( 7.into() ) ;
+  /// let n_var_1 = instance.op( Op::Not, vec![var_1] ) ;
+  ///
+  /// assert_eq!( var_1, Op::Not.simplify(instance, vec![ n_var_1 ]) ) ;
+  ///
+  /// let var_1 = instance.var( 7.into() ) ;
+  /// let n_var_1 = instance.op( Op::Not, vec![var_1] ) ;
+  /// assert_eq!( n_var_1, Op::Not.simplify(instance, vec![ var_1 ]) ) ;
+  /// ```
   pub fn simplify(
     self, instance: & Instance, mut args: Vec<Term>
   ) -> Term {
@@ -1008,6 +1285,16 @@ impl Op {
       } else if args.len() == 1 {
         return args.pop().unwrap()
       } else {
+        (self, args)
+      },
+      Op::Not => {
+        assert!( args.len() == 1 ) ;
+        match * args[0].get() {
+          RTerm::App { op: Op::Not, ref args } => {
+            return args[0].clone()
+          },
+          _ => (),
+        }
         (self, args)
       },
       // Op::Gt => if args.len() != 2 {

--- a/src/learning/ice/mining.rs
+++ b/src/learning/ice/mining.rs
@@ -130,28 +130,28 @@ impl Qualifiers {
         let _ = terms.insert( instance.ge(var.clone(), cst.clone()) ) ;
         let _ = terms.insert( instance.le(var.clone(), cst.clone()) ) ;
         let _ = terms.insert( instance.eq(var.clone(), cst.clone()) ) ;
-        for other_var in VarRange::zero_to( var_idx ) {
-          use instance::Op ;
-          let other_var = instance.var(other_var) ;
-          let add = instance.op(
-            Op::Add, vec![ var.clone(), other_var.clone() ]
-          ) ;
-          let _ = terms.insert( instance.ge(add.clone(), cst.clone()) ) ;
-          let _ = terms.insert( instance.le(add.clone(), cst.clone()) ) ;
-          let _ = terms.insert( instance.eq(add.clone(), cst.clone()) ) ;
-          let sub_1 = instance.op(
-            Op::Sub, vec![ var.clone(), other_var.clone() ]
-          ) ;
-          let _ = terms.insert( instance.ge(sub_1.clone(), cst.clone()) ) ;
-          let _ = terms.insert( instance.le(sub_1.clone(), cst.clone()) ) ;
-          let _ = terms.insert( instance.eq(sub_1.clone(), cst.clone()) ) ;
-          let sub_2 = instance.op(
-            Op::Sub, vec![ other_var, var.clone() ]
-          ) ;
-          let _ = terms.insert( instance.ge(sub_2.clone(), cst.clone()) ) ;
-          let _ = terms.insert( instance.le(sub_2.clone(), cst.clone()) ) ;
-          let _ = terms.insert( instance.eq(sub_2.clone(), cst.clone()) ) ;
-        }
+        // for other_var in VarRange::zero_to( var_idx ) {
+        //   use instance::Op ;
+        //   let other_var = instance.var(other_var) ;
+        //   let add = instance.op(
+        //     Op::Add, vec![ var.clone(), other_var.clone() ]
+        //   ) ;
+        //   let _ = terms.insert( instance.ge(add.clone(), cst.clone()) ) ;
+        //   let _ = terms.insert( instance.le(add.clone(), cst.clone()) ) ;
+        //   let _ = terms.insert( instance.eq(add.clone(), cst.clone()) ) ;
+        //   let sub_1 = instance.op(
+        //     Op::Sub, vec![ var.clone(), other_var.clone() ]
+        //   ) ;
+        //   let _ = terms.insert( instance.ge(sub_1.clone(), cst.clone()) ) ;
+        //   let _ = terms.insert( instance.le(sub_1.clone(), cst.clone()) ) ;
+        //   let _ = terms.insert( instance.eq(sub_1.clone(), cst.clone()) ) ;
+        //   let sub_2 = instance.op(
+        //     Op::Sub, vec![ other_var, var.clone() ]
+        //   ) ;
+        //   let _ = terms.insert( instance.ge(sub_2.clone(), cst.clone()) ) ;
+        //   let _ = terms.insert( instance.le(sub_2.clone(), cst.clone()) ) ;
+        //   let _ = terms.insert( instance.eq(sub_2.clone(), cst.clone()) ) ;
+        // }
       }
       arity_map.push(
         terms.into_iter().map(
@@ -240,6 +240,25 @@ impl Qualifiers {
   //   }
   //   Ok(())
   // }
+
+  /// Adds a qualifier whithout doing anything.
+  pub fn new_add_qual<'a>(& 'a mut self, qual: Term) -> Res<()> {
+    let arity: Arity = if let Some(max_var) = qual.highest_var() {
+      (1 + * max_var).into()
+    } else {
+      bail!("[bug] trying to add constant qualifier")
+    } ;
+    debug_assert!({
+      for values in self.arity_map[arity].iter() {
+        assert!(& values.qual != & qual)
+      }
+      true
+    }) ;
+    let values = QualValues::mk( qual ) ;
+    // The two operations below make sense iff `arity_map` is not shared.
+    self.arity_map[arity].push( values ) ;
+    Ok(())
+  }
 
 
   /// Adds a qualifier.


### PR DESCRIPTION
- bug fixes
- lazy qualifier evaluation
- simplified the `TopTerm` enum (removed negated terms)
- implemented several substitution strategies for different use-cases (here mostly for mining)
- made it impossible to create double negations
- tweaked profiling a bit (not done with that)
- library updates

# `fpice` style synthesis

When some samples cannot be separated by the current qualifiers, for each of these samples generate new special qualifiers that will discriminate them.

For a sample `(7, 3)` for instance, generate

- `v_1 >= 7`, `v_1 <= 7`, `v_1 == 7`,
- `v_2 >= 3`, `v_2 <= 3`, `v_2 == 3`,
- `v_1 + v_2 >= 10`, `v_1 + v_2 <= 10`, `v_1 - v_2 >= 4`, ...

This replaces the previous *SMT-style* qualifier synthesis that did not work extremely well.

# Clause simplification

Top terms in the *LHS* that are equalities are now propagated. This might not always be a good idea, for instance if the clause is huge, but makes mining much easier. This will have to be evaluated on bigger systems.

# Modified mining

The previous mining strategy ---generating many qualifiers using all the constants in the program indiscriminately--- was tuned down and does not generate relational qualifiers anymore.

Instead, the clauses are now mined based on how they apply predicates, and perform substitutions in the rest of the clause to generate (hopefully) relevant qualifiers.

Unsurprisingly, this generates *far less* qualifiers than the previous, more exhaustive approach.

# Better handling of trivial cases when learning predicates

While this only impacted 4 lines of the code, it made a huge different in the experiments. The difference is basically

```diff
-      if pos_len == 0 && neg_len != 0 {
+      if pos_len == 0 {
```
and

```diff
-      } else if neg_len == 0 && pos_len != 0 {
+      }
+      if neg_len == 0 {
```

in the part that decides which predicates to learn first in the ice learner.

