### PR TITLE
Optimizations + parallel qualifier gain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,7 @@ dependencies = [
  "mylib 0.1.0 (git+https://github.com/AdrienChampion/mylib)",
  "nom 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rsmt2 0.6.0 (git+https://github.com/kino-mc/rsmt2)",
 ]
@@ -94,6 +95,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "coco"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "conv"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +126,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "env_logger"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +146,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "futures"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "gcc"
@@ -275,12 +295,41 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "num_cpus"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rand"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rayon"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rayon-core 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -317,6 +366,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rustc-serialize"
 version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "scopeguard"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -405,11 +459,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2267a8fdd4dce6956ba6649e130f62fb279026e5e84b92aa939ac8f85ce3f9f0"
+"checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
 "checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
 "checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
+"checksum either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18785c1ba806c258137c937e44ada9ee7e69a37e3c72077542cd2f069d78562a"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
 "checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
+"checksum futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4b63a4792d4f8f686defe3b39b92127fea6344de5d38202b2ee5a11bbbf29d6a"
 "checksum gcc 0.3.53 (registry+https://github.com/rust-lang/crates.io-index)" = "e8310f7e9c890398b0e80e301c4f474e9918d2b27fca8f48486ca775fa9ffc5a"
 "checksum hashconsing 0.6.0 (git+https://github.com/AdrienChampion/hashconsing)" = "<none>"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
@@ -428,12 +485,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "7485fcc84f85b4ecd0ea527b14189281cf27d60e583ae65ebc9c088b13dffe01"
 "checksum num-rational 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "288629c76fac4b33556f4b7ab57ba21ae202da65ba8b77466e6d598e31990790"
 "checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
+"checksum num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aec53c34f2d0247c5ca5d32cca1478762f301740468ee9ee6dcb7a0dd7a0c584"
 "checksum rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "eb250fd207a4729c976794d03db689c9be1d634ab5a1c9da9492a13d8fecbcdf"
+"checksum rayon 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b614fe08b6665cb9a231d07ac1364b0ef3cb3698f1239ee0c4c3a88a524f54c8"
+"checksum rayon-core 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7febc28567082c345f10cddc3612c6ea020fc3297a1977d472cf9fdb73e6e493"
 "checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum rsmt2 0.6.0 (git+https://github.com/kino-mc/rsmt2)" = "<none>"
 "checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+"checksum scopeguard 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c79eb2c3ac4bc2507cda80e7f3ac5b88bd8eae4c0914d5663e6a8933994be918"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b6b55df3198cc93372e85dd2ed817f0e38ce8cc0f22eb32391bfad9c4bf209"
 "checksum textwrap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f728584ea33b0ad19318e20557cb0a39097751dbb07171419673502f848c7af6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ ansi_term = "*"
 rsmt2 = { git = "https://github.com/kino-mc/rsmt2" }
 num = "*"
 mylib = { git = "https://github.com/AdrienChampion/mylib" }
+rayon = "*"
 
 [dependencies.nom]
 version = "^3.0"

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -367,6 +367,7 @@ pub struct Conf {
   pub smt_learn: bool,
   pub z3_cmd: String,
   pub fpice_synth: bool,
+  pub para_gain: bool,
   pub step: bool,
   pub verb: Verb,
   pub stats: bool,
@@ -380,12 +381,12 @@ impl Conf {
   pub fn mk(
     file: Option<String>, check: Option<String>,
     smt_log: bool, z3_cmd: String, out_dir: String,
-    step: bool, smt_learn: bool, fpice_synth: bool,
+    step: bool, smt_learn: bool, fpice_synth: bool, para_gain: bool,
     verb: Verb, stats: bool, color: bool
   ) -> Self {
     Conf {
-      file, check, smt_log, out_dir, step, smt_learn, fpice_synth, z3_cmd,
-      verb, stats, styles: Styles::mk(color)
+      file, check, smt_log, out_dir, step, smt_learn, fpice_synth, para_gain,
+      z3_cmd, verb, stats, styles: Styles::mk(color)
     }
   }
 
@@ -525,12 +526,22 @@ impl Conf {
     // ).arg(
 
     //   Arg::with_name("fpice_synth").long("--fpice_synth").help(
-    //     "activates fpice-style synthesis"
+    //     "(de)activates fpice-style synthesis"
     //   ).validator(
     //     bool_validator
     //   ).value_name(
     //     bool_format
     //   ).default_value("on").takes_value(true).number_of_values(1)
+
+    ).arg(
+
+      Arg::with_name("para_gain").long("--para_gain").help(
+        "(de)activates parallel gain computation"
+      ).validator(
+        bool_validator
+      ).value_name(
+        bool_format
+      ).default_value("on").takes_value(true).number_of_values(1)
 
     ).arg(
 
@@ -580,6 +591,11 @@ impl Conf {
     // ).expect(
     //   "unreachable(fpice_synth): default is provided and input validated in clap"
     // ) ;
+    let para_gain = matches.value_of("para_gain").and_then(
+      |s| bool_of_str(& s)
+    ).expect(
+      "unreachable(para_gain): default is provided and input validated in clap"
+    ) ;
     let stats = matches.value_of("stats").and_then(
       |s| bool_of_str(& s)
     ).expect(
@@ -597,7 +613,7 @@ impl Conf {
 
     Conf::mk(
       file, check, smt_log, z3_cmd.into(), out_dir.into(), step, smt_learn,
-      fpice_synth, verb, stats, color
+      fpice_synth, para_gain, verb, stats, color
     )
   }
 }

--- a/src/learning/ice/mining.rs
+++ b/src/learning/ice/mining.rs
@@ -177,9 +177,7 @@ impl Qualifiers {
       blacklist: HConSet::with_capacity(107),
     } ;
 
-    for qual in instance.qualifiers() {
-      quals.new_add_qual(qual) ?
-    }
+    quals.add_quals( instance.qualifiers() ) ? ;
 
     Ok(quals)
   }
@@ -258,65 +256,84 @@ impl Qualifiers {
   // }
 
   /// Adds a qualifier whithout doing anything.
-  pub fn new_add_qual<'a>(& 'a mut self, qual: Term) -> Res<()> {
-    let arity: Arity = if let Some(max_var) = qual.highest_var() {
-      (1 + * max_var).into()
-    } else {
-      bail!("[bug] trying to add constant qualifier")
-    } ;
-    let values = QualValues::mk( qual ) ;
-    // The two operations below make sense iff `arity_map` is not shared.
-    self.arity_map[arity].push( values ) ;
+  pub fn add_quals<'a, Terms: IntoIterator<Item = Term>>(
+    & 'a mut self, quals: Terms
+  ) -> Res<()> {
+    for qual in quals {
+      let arity: Arity = if let Some(max_var) = qual.highest_var() {
+        (1 + * max_var).into()
+      } else {
+        bail!("[bug] trying to add constant qualifier")
+      } ;
+      let values = QualValues::mk( qual ) ;
+      self.arity_map[arity].push( values )
+    }
+    Ok(())
+  }
+
+  /// Adds a qualifier whithout doing anything.
+  pub fn add_qual_values<'a, Terms: IntoIterator<Item = QualValues>>(
+    & 'a mut self, quals: Terms
+  ) -> Res<()> {
+    for values in quals {
+      let arity: Arity = if let Some(max_var) = values.qual.highest_var() {
+        (1 + * max_var).into()
+      } else {
+        bail!("[bug] trying to add constant qualifier")
+      } ;
+      self.arity_map[arity].push( values )
+    }
     Ok(())
   }
 
 
-  /// Adds a qualifier.
-  pub fn add_qual<'a>(
-    & 'a mut self, qual: Term
-    // , samples: & ::common::data::HSampleConsign
-  ) -> Res<& 'a mut QualValues> {
-    let arity: Arity = if let Some(max_var) = qual.highest_var() {
-      (1 + * max_var).into()
-    } else {
-      bail!("[bug] trying to add constant qualifier")
-    } ;
-    // let values = samples.read().map_err(
-    //   corrupted_err
-    // )?.fold(
-    //   |mut values, sample| {
-    //     if sample.len() >= * arity {
-    //       match qual.bool_eval(& * sample) {
-    //         Ok( Some(b) ) => values.add(sample, b),
-    //         Ok( None ) => panic!(
-    //           "incomplete model, cannot evaluate qualifier"
-    //         ),
-    //         Err(e) => panic!(
-    //           "[bug] error while evaluating qualifier: {}", e
-    //         ),
-    //       }
-    //     }
-    //     values
-    //   }, QualValues::mk( qual.clone() )
-    // ) ;
-    debug_assert!({
-      for values in self.arity_map[arity].iter() {
-        assert!(& values.qual != & qual)
-      }
-      true
-    }) ;
-    let values = QualValues::mk( qual ) ;
+  // /// Adds a qualifier.
+  // pub fn add_qual<'a>(
+  //   & 'a mut self, qual: Term
+  //   // , samples: & ::common::data::HSampleConsign
+  // ) -> Res<& 'a mut QualValues> {
+  //   let arity: Arity = if let Some(max_var) = qual.highest_var() {
+  //     (1 + * max_var).into()
+  //   } else {
+  //     bail!("[bug] trying to add constant qualifier")
+  //   } ;
+  //   // let values = samples.read().map_err(
+  //   //   corrupted_err
+  //   // )?.fold(
+  //   //   |mut values, sample| {
+  //   //     if sample.len() >= * arity {
+  //   //       match qual.bool_eval(& * sample) {
+  //   //         Ok( Some(b) ) => values.add(sample, b),
+  //   //         Ok( None ) => panic!(
+  //   //           "incomplete model, cannot evaluate qualifier"
+  //   //         ),
+  //   //         Err(e) => panic!(
+  //   //           "[bug] error while evaluating qualifier: {}", e
+  //   //         ),
+  //   //       }
+  //   //     }
+  //   //     values
+  //   //   }, QualValues::mk( qual.clone() )
+  //   // ) ;
+  //   debug_assert!({
+  //     for values in self.arity_map[arity].iter() {
+  //       assert!(& values.qual != & qual)
+  //     }
+  //     true
+  //   }) ;
+  //   let values = QualValues::mk( qual ) ;
     
-    // The two operations below make sense iff `arity_map` is not shared.
-    self.arity_map[arity].push( values ) ;
-    // If it was shared, someone could insert between these two lines.
-    let last_values = self.arity_map[arity].last_mut().unwrap() ;
-    //                                                 ^^^^^^^^|
-    // Definitely safe right after the push -------------------|
+  //   // The two operations below make sense iff `arity_map` is not shared.
+  //   self.arity_map[arity].push( values ) ;
+  //   // If it was shared, someone could insert between these two lines.
+  //   let last_values = self.arity_map[arity].last_mut().unwrap() ;
+  //   //                                                 ^^^^^^^^|
+  //   // Definitely safe right after the push -------------------|
 
-    Ok(last_values)
-  }
+  //   Ok(last_values)
+  // }
 }
+
 
 
 

--- a/src/learning/ice/mod.rs
+++ b/src/learning/ice/mod.rs
@@ -672,7 +672,7 @@ where Slver: Solver<'kid, Parser> + ::rsmt2::QueryIdent<'kid, Parser, ()> {
 
       // Could not close the branch, look for a qualifier.
       profile!{ self tick "learning", "qual" }
-      let (qual, q_data, nq_data) = self.get_qualifier(pred, data, true) ? ;
+      let (qual, q_data, nq_data) = self.get_qualifier(pred, data) ? ;
       profile!{ self mark "learning", "qual" }
       self.qualifiers.blacklist(& qual) ;
 
@@ -709,15 +709,15 @@ where Slver: Solver<'kid, Parser> + ::rsmt2::QueryIdent<'kid, Parser, ()> {
   }
 
   /// Gets the best qualifier if any, parallel version using `rayon`.
-  pub fn get_best_qualifier_para<'a>(
-    profiler: & Profile, all_data: & Data,
-    pred: PrdIdx, data: & CData, quals: QualIter<'a>
+  pub fn get_best_qualifier_para<
+    'a, I: ::rayon::iter::IntoParallelIterator<Item = & 'a mut QualValues>
+  >(
+    _profiler: & Profile, all_data: & Data,
+    pred: PrdIdx, data: & CData, quals: I
   ) -> Res< Option< (f64, & 'a mut QualValues) > > {
     use rayon::prelude::* ;
 
-    profile!{ |profiler| tick "learning", "qual", "// gain" }
-
-    let quals: Vec<_> = quals.collect() ;
+    profile!{ |_profiler| tick "learning", "qual", "// gain" }
 
     let mut gains: Vec<_> = quals.into_par_iter().map(
       |values| match data.gain(pred, all_data, values) {
@@ -727,9 +727,9 @@ where Slver: Solver<'kid, Parser> + ::rsmt2::QueryIdent<'kid, Parser, ()> {
       }
     ).collect() ;
 
-    profile!{ |profiler| mark "learning", "qual", "// gain" }
+    profile!{ |_profiler| mark "learning", "qual", "// gain" }
 
-    profile!{ |profiler| tick "learning", "qual", "gain sort" }
+    profile!{ |_profiler| tick "learning", "qual", "gain sort" }
 
     gains.sort_by(
       |lft, rgt| {
@@ -751,7 +751,7 @@ where Slver: Solver<'kid, Parser> + ::rsmt2::QueryIdent<'kid, Parser, ()> {
       }
     ) ;
 
-    profile!{ |profiler| mark "learning", "qual", "gain sort" }
+    profile!{ |_profiler| mark "learning", "qual", "gain sort" }
 
     if let Some(res) = gains.pop() { res } else {
       bail!("[bug] empty QualIter")
@@ -759,13 +759,15 @@ where Slver: Solver<'kid, Parser> + ::rsmt2::QueryIdent<'kid, Parser, ()> {
   }
 
   /// Gets the best qualifier if any, sequential version.
-  pub fn get_best_qualifier<'a>(
-    profiler: & Profile, all_data: & Data,
-    pred: PrdIdx, data: & CData, quals: QualIter<'a>
+  pub fn get_best_qualifier_seq<
+    'a, I: IntoIterator<Item = & 'a mut QualValues>
+  >(
+    _profiler: & Profile, all_data: & Data,
+    pred: PrdIdx, data: & CData, quals: I,
   ) -> Res< Option< (f64, & 'a mut QualValues) > > {
     let mut maybe_qual: Option<(f64, & mut QualValues)> = None ;
 
-    profile!{ |profiler| tick "learning", "qual", "gain" }
+    profile!{ |_profiler| tick "learning", "qual", "gain" }
     'search_qual: for values in quals {
       if let Some(
         (gain, (_q_pos, _q_neg, _q_unc), (_nq_pos, _nq_neg, _nq_unc))
@@ -779,9 +781,28 @@ where Slver: Solver<'kid, Parser> + ::rsmt2::QueryIdent<'kid, Parser, ()> {
         if gain == 1. { break 'search_qual }
       }
     }
-    profile!{ |profiler| mark "learning", "qual", "gain" }
+    profile!{ |_profiler| mark "learning", "qual", "gain" }
 
     Ok( maybe_qual )
+  }
+
+  /// Gets the best qualifier if any.
+  pub fn get_best_qualifier<
+    'a, I: IntoIterator<Item = & 'a mut QualValues>
+  >(
+    profiler: & Profile, all_data: & Data,
+    pred: PrdIdx, data: & CData, quals: I,
+  ) -> Res< Option< (f64, & 'a mut QualValues) > > {
+    if conf.gain_threads <= 1 {
+      Self::get_best_qualifier_seq(
+        profiler, all_data, pred, data, quals.into_iter()
+      )
+    } else {
+      let quals: Vec<_> = quals.into_iter().collect() ;
+      Self::get_best_qualifier_para(
+        profiler, all_data, pred, data, quals
+      )
+    }
   }
 
   /// Looks for a qualifier. Requires a mutable `self` in case it needs to
@@ -793,20 +814,12 @@ where Slver: Solver<'kid, Parser> + ::rsmt2::QueryIdent<'kid, Parser, ()> {
   /// The recursive call is logically guaranteed not cause further calls and
   /// terminate right away. Please be careful to preserve this.
   pub fn get_qualifier(
-    & mut self, pred: PrdIdx, data: CData, first_iteration: bool,
+    & mut self, pred: PrdIdx, data: CData
   ) -> Res< (Term, CData, CData) > {
 
-    if let Some( (_gain, values) ) = if ! conf.para_gain {
-      Self::get_best_qualifier(
-        & self._profiler, & self.data,
-        pred, & data, self.qualifiers.of(pred)
-      ) ?
-    } else {
-      Self::get_best_qualifier_para(
-        & self._profiler, & self.data,
-        pred, & data, self.qualifiers.of(pred)
-      ) ?
-    } {
+    if let Some( (_gain, values) ) = Self::get_best_qualifier(
+      & self._profiler, & self.data, pred, & data, self.qualifiers.of(pred)
+    ) ? {
       let (q_data, nq_data) = data.split(values) ;
       msg!(
         self.core =>
@@ -854,7 +867,7 @@ where Slver: Solver<'kid, Parser> + ::rsmt2::QueryIdent<'kid, Parser, ()> {
 
     // Synthesize qualifier separating the data.
     profile!{ self tick "learning", "qual", "synthesis" }
-    if conf.fpice_synth {
+    let mut new_quals: Vec<QualValues> = if conf.fpice_synth {
       let mut quals = HConSet::new() ;
       if data.pos.is_empty() && data.neg.is_empty() && data.unc.is_empty() {
         bail!("[bug] cannot synthesize qualifier based on no data")
@@ -868,12 +881,10 @@ where Slver: Solver<'kid, Parser> + ::rsmt2::QueryIdent<'kid, Parser, ()> {
       for sample in & data.unc {
         Self::synthesize(& * self.instance, sample, & mut quals)
       }
-      
+
       profile!{ self "qualifier synthesized" => add quals.len() }
 
-      for qual in quals {
-        self.qualifiers.new_add_qual(qual) ?
-      }
+      quals.into_iter().map(QualValues::mk).collect()
     } else {
       let qual = match (
         data.pos.is_empty(), data.neg.is_empty(), data.unc.is_empty()
@@ -904,18 +915,47 @@ where Slver: Solver<'kid, Parser> + ::rsmt2::QueryIdent<'kid, Parser, ()> {
         ),
       } ;
       profile!{ self "qualifier synthesized" => add 1 }
-      self.qualifiers.new_add_qual(qual) ?
-    }
+      vec![ QualValues::mk(qual) ]
+    } ;
     profile!{ self mark "learning", "qual", "synthesis" }
 
-    if ! first_iteration {
-      panic!("could not conclude on second iteration...")
-    }
+    
+    let res = if let Some( (_gain, values) ) = Self::get_best_qualifier(
+      & self._profiler, & self.data, pred, & data, new_quals.iter_mut()
+    ) ? {
+      let (q_data, nq_data) = data.split(values) ;
+      msg!(
+        self.core =>
+          "  using synthetic qualifier {} | \
+          gain: {}, pos: ({},{},{}), neg: ({},{},{})",
+          values.qual.string_do(
+            & self.instance[pred].sig.index_iter().map(
+              |(idx, typ)| ::instance::info::VarInfo {
+                name: format!("v_{}", idx), typ: * typ, idx
+              }
+            ).collect(), |s| s.to_string()
+          ).unwrap(),
+          _gain,
+          q_data.pos.len(),
+          q_data.neg.len(),
+          q_data.unc.len(),
+          nq_data.pos.len(),
+          nq_data.neg.len(),
+          nq_data.unc.len(),
+      ) ;
+      Ok( (values.qual.clone(), q_data, nq_data) )
+    } else {
+      bail!("[bug] unable to split the data after synthesis...")
+    } ;
+
+    self.qualifiers.add_qual_values(new_quals) ? ;
+
+    res
 
     // RECURSIVE CALL.
     //
     // It's fine, the next call is logically obligated to terminate.
-    self.get_qualifier(pred, data, false)
+    // self.get_qualifier(pred, data, false)
 
     // // Insert new qualifier.
     // let (q_data, nq_data) = {

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ extern crate hashconsing ;
 #[macro_use]
 extern crate rsmt2 ;
 extern crate num ;
+extern crate rayon ;
 
 pub mod errors ;
 #[macro_use]


### PR DESCRIPTION
# Minor

- optimized post qualifier synthesis gain computations

# Parallel qualifier gain

Using the [`rayon`](https://crates.io/crates/rayon) crate. Compute the gain of each qualifier in a parallel, work-stealing fashion.

This is optional and not active by default. It is controlled by the `--gain_threads` CLA. When set to `0` or `1`, the sequential version is used instead (default is `1`).