### PR TITLE
Specify clap's version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ bench = [ ]
 [dependencies]
 libc = "*"
 lazy_static = "*"
-clap = { version = "*", features = ["cargo"] }
+clap = { version = "3.1.18", features = ["cargo"] }
 hashconsing = "^1"
 error-chain = "*"
 ansi_term = "*"


### PR DESCRIPTION
Specifying clap's version seems necessary to avoid using "too new" clap which is specified in other crates on which hoice depends.

### detail

Currently, `cargo install --git https://github.com/hopv/hoice` fails because of build failure. 

```
   Compiling hoice v1.10.0 (/home/runner/.cargo/git/checkouts/hoice-f457c25b6b654cac/90d3489)
error[E0107]: this struct takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> src/common/config.rs:140:24
    |
140 | pub type App = ::clap::Command<'static>;
    |                        ^^^^^^^--------- help: remove these generics
    |                        |
    |                        expected 0 lifetime arguments
    |
note: struct defined here, with 0 lifetime parameters
   --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.0.2/src/builder/command.rs:71:12
    |
71  | pub struct Command {
    |            ^^^^^^^

For more information about this error, try `rustc --explain E0107`.
error: could not compile `hoice` due to previous error
```

This happens because `cargo install` ignores `Cargo.lock` by default.
Actually, if you install hoice by `cargo install --git https://github.com/hopv/hoice --locked`, the installation succeeds.
A similar issue is, for example, https://github.com/denoland/deno/issues/8992 .

The problem is that no clap's version is specified (just `*`) in `Cargo.toml`.
Perhaps, specifying `3.1.18` is too strict (I think `3` is sufficient), but it is used in the current `Cargo.lock`, so I used it.

Note that CI fails for my commit currently, but this happens because it's already broken as I reported an [issue](https://github.com/hopv/hoice/issues/59).
