### PR TITLE
fix: improve preproc triviality checks

### DIFF
--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -16,7 +16,7 @@ use crate::{common::mk_dir, errors::*, instance::Instance};
 macro_rules! app_fun {
     // Internal rules.
     (@app $app:expr, $order:expr =>) => ($app);
-    (@app $app:expr, $o7rder:expr =>
+    (@app $app:expr, $order:expr =>
         , $($tail:tt)*
     ) => (
         app_fun!(@app $app, $order => $($tail)*)
@@ -1177,6 +1177,12 @@ impl Config {
     #[inline]
     pub fn check_file(&self) -> Option<&String> {
         self.check.as_ref()
+    }
+
+    /// True if a timeout was specified.
+    #[inline]
+    pub fn has_timeout(&self) -> bool {
+        self.timeout.is_some()
     }
 
     /// Checks if we're out of time.

--- a/src/common/smt.rs
+++ b/src/common/smt.rs
@@ -62,7 +62,7 @@ pub fn preproc_reset<P>(solver: &mut Solver<P>) -> Res<()> {
 }
 
 /// Performs a check-sat.
-pub fn tmo_multi_try_check_sat<P, F>(
+pub fn tmo_multi_try_check_sat_legacy<P, F>(
     solver: &mut Solver<P>,
     tmo: ::std::time::Duration,
     do_stuff: F,
@@ -85,6 +85,44 @@ where
         solver.set_option(":timeout", "1000000000")?;
         multi_try_check_sat(solver)
     }
+}
+
+/// Performs a check-sat.
+pub fn tmo_multi_check_sat<P, F>(
+    solver: &mut Solver<P>,
+    tmo: ::std::time::Duration,
+    do_stuff: F,
+) -> Res<bool>
+where
+    F: FnOnce(&mut Solver<P>) -> Res<()>,
+{
+    solver.set_option(":timeout", &format!("{}000", tmo.as_secs()))?;
+    if let Some(res) = multi_try_check_sat_or_unk(solver)? {
+        return Ok(res);
+    }
+    do_stuff(solver)?;
+    if let Some(res) = multi_try_check_sat_or_unk(solver)? {
+        Ok(res)
+    } else {
+        bail!(crate::errors::ErrorKind::Unknown)
+    }
+}
+
+/// Performs a check-sat.
+pub fn tmo_multi_try_check_sat<P, F>(
+    solver: &mut Solver<P>,
+    tmo: ::std::time::Duration,
+    do_stuff: F,
+) -> Res<Option<bool>>
+where
+    F: FnOnce(&mut Solver<P>) -> Res<()>,
+{
+    solver.set_option(":timeout", &format!("{}000", tmo.as_secs()))?;
+    if let Some(res) = multi_try_check_sat_or_unk(solver)? {
+        return Ok(Some(res));
+    }
+    do_stuff(solver)?;
+    multi_try_check_sat_or_unk(solver)
 }
 
 /// Performs a check-sat.
@@ -298,18 +336,43 @@ where
         }
 
         solver.assert_with(self, false)?;
-        let sat = tmo_multi_try_check_sat(
+        let sat = tmo_multi_check_sat(
             solver,
             conf.until_timeout()
-                .map(|time| time / 20)
+                .map(|time| time / 100)
                 .unwrap_or_else(|| ::std::time::Duration::new(1, 0)),
             |solver| {
                 solver.assert_with(self, true)?;
                 Ok(())
             },
-            true,
         )?;
         Ok(!sat)
+    }
+
+    /// Checks if this conjunction is unsatisfiable.
+    fn try_is_unsat<Parser: Copy>(&self, solver: &mut Solver<Parser>) -> Res<Option<bool>> {
+        if self.terms.len() == 0 {
+            return Ok(Some(false));
+        }
+        for var in self.infos {
+            if var.active {
+                solver.declare_const(&var.idx, var.typ.get())?
+            }
+        }
+
+        solver.assert_with(self, false)?;
+        let is_unsat = tmo_multi_try_check_sat(
+            solver,
+            conf.until_timeout()
+                .map(|time| time / 100)
+                .unwrap_or_else(|| ::std::time::Duration::new(1, 0)),
+            |solver| {
+                solver.assert_with(self, true)?;
+                Ok(())
+            },
+        )?
+        .map(|b| !b);
+        Ok(is_unsat)
     }
 }
 
@@ -1033,7 +1096,7 @@ impl<Parser: Copy> ClauseTrivialExt for Solver<Parser> {
                 if lhs.is_empty() {
                     Ok(Some(false))
                 } else {
-                    conj.is_unsat(self).map(Some)
+                    conj.try_is_unsat(self)
                 }
             }
         };

--- a/src/common/smt.rs
+++ b/src/common/smt.rs
@@ -336,7 +336,7 @@ where
         }
 
         solver.assert_with(self, false)?;
-        let sat = tmo_multi_check_sat(
+        let sat = tmo_multi_try_check_sat_legacy(
             solver,
             conf.until_timeout()
                 .map(|time| time / 100)
@@ -345,6 +345,7 @@ where
                 solver.assert_with(self, true)?;
                 Ok(())
             },
+            !conf.has_timeout(),
         )?;
         Ok(!sat)
     }

--- a/src/common/smt.rs
+++ b/src/common/smt.rs
@@ -1097,7 +1097,10 @@ impl<Parser: Copy> ClauseTrivialExt for Solver<Parser> {
                 if lhs.is_empty() {
                     Ok(Some(false))
                 } else {
-                    conj.try_is_unsat(self)
+                    match conj.try_is_unsat(self) {
+                        Ok(Some(true)) => Ok(Some(true)),
+                        _ => Ok(Some(false)),
+                    }
                 }
             }
         };

--- a/src/teacher.rs
+++ b/src/teacher.rs
@@ -1013,7 +1013,7 @@ impl<'a> Teacher<'a> {
                         let tru_preds = & self.tru_preds;
                         let fls_preds = & self.fls_preds;
                         let instance = & self.instance;
-                        smt::tmo_multi_try_check_sat(
+                        smt::tmo_multi_try_check_sat_legacy(
                             solver,
                             conf.until_timeout().map(
                                 |time| time / 20


### PR DESCRIPTION
- adds a timeout for *is-trivial* checks during pre-processing on clauses with a generic shape (has predicates and a rhs)

- for clauses with no predicates nor rhs, the *is-trivial* check is **still** unbounded when hoice has no timeout as, currently, a timeout/unknown result at this stage stops the whole analysis

  But if hoice does run with a timeout, the checks will now have one as well

closes #67 