### PR TITLE
Use word_opt instead of tag_opt

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1700,7 +1700,7 @@ impl<'cxt, 's> Parser<'cxt, 's> {
 
             if let Some(pos) = self.tag_opt_pos("(") {
                 self.ws_cmt();
-                if self.tag_opt(keywords::let_) {
+                if self.word_opt(keywords::let_) {
                     n += 1;
                     self.push_bind();
                     self.ws_cmt();
@@ -1751,21 +1751,10 @@ impl<'cxt, 's> Parser<'cxt, 's> {
 
     /// Bool parser.
     pub fn bool(&mut self) -> Option<bool> {
-        let start_pos = self.pos();
-        if self.tag_opt("true") {
-            if !self.legal_id_char() {
-                Some(true)
-            } else {
-                self.backtrack_to(start_pos);
-                None
-            }
-        } else if self.tag_opt("false") {
-            if !self.legal_id_char() {
-                Some(false)
-            } else {
-                self.backtrack_to(start_pos);
-                None
-            }
+        if self.word_opt("true") {
+            Some(true)
+        } else if self.word_opt("false") {
+            Some(false)
         } else {
             None
         }
@@ -2411,7 +2400,7 @@ impl<'cxt, 's> Parser<'cxt, 's> {
                     op_pos,
                     bind_count,
                 )));
-            } else if self.tag_opt(keywords::op::as_) {
+            } else if self.word_opt(keywords::op::as_) {
                 return Ok(TermTokenRes::Push(TermFrame::new(
                     FrameOp::Cast,
                     op_pos,
@@ -2436,7 +2425,7 @@ impl<'cxt, 's> Parser<'cxt, 's> {
                         op_pos,
                         bind_count,
                     )));
-                } else if self.tag_opt(keywords::op::lambda_) {
+                } else if self.word_opt(keywords::op::lambda_) {
                     self.ws_cmt();
                     self.word(keywords::op::is_)?;
                     self.ws_cmt();
@@ -2981,16 +2970,16 @@ impl<'cxt, 's> Parser<'cxt, 's> {
             let mut ptterm = if let Some(pos) = self.tag_opt_pos("(") {
                 self.ws_cmt();
 
-                if self.tag_opt("and") {
+                if self.word_opt("and") {
                     stack.push(Frame::And(vec![]));
                     continue 'go_down;
-                } else if self.tag_opt("or") {
+                } else if self.word_opt("or") {
                     stack.push(Frame::Or(vec![]));
                     continue 'go_down;
-                } else if self.tag_opt("not") {
+                } else if self.word_opt("not") {
                     stack.push(Frame::Not);
                     continue 'go_down;
-                } else if self.tag_opt("=>") {
+                } else if self.word_opt("=>") {
                     stack.push(Frame::Impl(vec![]));
                     continue 'go_down;
                 } else {
@@ -3403,9 +3392,9 @@ impl<'cxt, 's> Parser<'cxt, 's> {
 
         let bind_count = self.let_bindings(&VarMap::new(), &BTreeMap::new(), instance)?;
 
-        let idx = if self.tag_opt("true") {
+        let idx = if self.word_opt("true") {
             ClauseRes::Skipped
-        } else if self.tag_opt("false") {
+        } else if self.word_opt("false") {
             ClauseRes::Skipped
         } else {
             self.ws_cmt();


### PR DESCRIPTION
## Changes Made

I changed `tag_opt` to `word_opt` to handle identifiers correctly.

## Bugs Fixed

Previously, there was a bug that produced an error like the following:
```
(declare-fun andx (Int) Bool)
(assert (andx 1))
(error "
  unknown identifier x at [2:13]:
    |
  2 | (assert (andx 1))
    |             ^
")
```

This occurred because HoIce's parser behaved as follows:

```rust
if self.tag_opt("and") {
                stack.push(Frame::And(vec![]));
                continue 'go_down;
```

`tag_opt` only checks if the first three characters match "and", but it doesn't verify if the next character is an alphabetic character or something that can be part of an identifier.

The correct functionality is provided by `word_opt`, so I updated some uses of `tag_opt` to `word_opt`.
